### PR TITLE
auth command revision

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -5,9 +5,13 @@ import (
 
 	"github.com/bitrise-core/bitrise-plugins-io/configs"
 	"github.com/bitrise-core/bitrise-plugins-io/services"
-	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+)
+
+const (
+	personalAccessTokenRegURL = "https://www.bitrise.io/me/profile#/security"
 )
 
 var (
@@ -16,43 +20,26 @@ var (
 
 var authCmd = &cobra.Command{
 	Use:   "auth",
-	Short: "Authenticate",
-	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) > 1 {
-			log.Errorf("More than one argument specified (%+v), only one (the API Token) should be", args)
-			os.Exit(1)
-		}
+	Short: "Authenticate with the specified --token",
+	Long: `Authenticate with the specified --token
 
-		tokenToAuth := ""
-		if flagAPIToken != "" {
-			if len(args) > 0 {
-				log.Errorf("Both the --token flag as well as a token arg (%+v) is specified. Only one should be", args)
-				os.Exit(1)
-			}
-			tokenToAuth = flagAPIToken
-		} else if len(args) == 1 {
-			tokenToAuth = args[0]
-		}
-
-		if err := auth(tokenToAuth); err != nil {
-			log.Errorf(err.Error())
-			os.Exit(1)
-		}
-	},
+` + colorstring.Green("You can register a new Personal Access Token at:") + " " + personalAccessTokenRegURL,
+	Example: `auth --token=B1triseI0PersonalAccessT0ken`,
+	RunE:    auth,
 }
 
 func init() {
 	rootCmd.AddCommand(authCmd)
-	authCmd.Flags().StringVar(&flagAPIToken, "token", "", "Authentication token")
+	authCmd.Flags().StringVar(&flagAPIToken, "token", "", "Personal Access token")
 	authCmd.Flags().StringVar(&formatFlag, "format", "pretty", "Output format, one of: [pretty, json]")
 }
 
-func auth(apiToken string) error {
-	if apiToken == "" {
-		return errors.New("Failed to set authentication token, error: no API Token specified")
+func auth(cmd *cobra.Command, args []string) error {
+	if flagAPIToken == "" {
+		return NewInputError("No Personal Access Token specified. Register one at: " + personalAccessTokenRegURL)
 	}
 
-	if err := configs.SetAPIToken(apiToken); err != nil {
+	if err := configs.SetAPIToken(flagAPIToken); err != nil {
 		return errors.Errorf("Failed to set authentication token, error: %s", err)
 	}
 

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,17 @@
+package cmd
+
+// InputError ...
+type InputError struct {
+	Err string
+}
+
+func (e *InputError) Error() string {
+	return e.Err
+}
+
+// NewInputError ...
+func NewInputError(err string) error {
+	return &InputError{
+		Err: err,
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,9 @@ import (
 	"os"
 
 	"github.com/bitrise-core/bitrise-plugins-io/configs"
+	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/envutil"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +32,12 @@ If you use it as a stand-alone tool:
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Printf("%+v", err)
+		if inputErr, ok := errors.Cause(err).(*InputError); ok {
+			fmt.Printf(colorstring.Red("INPUT ERROR:")+" %s\n", inputErr)
+		} else {
+			// print with stack trace
+			fmt.Printf("%+v\n", err)
+		}
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
- no longer accepts token as just a parameter, have to be specified with the `--token` flag
- better error messsage in case of missing token parameter
- include info about where Personal Access Token can be registered (the URL)
- new InputError type, for input related errors which don't require the stack trace to be printed

fixes #19 