### PR TITLE
auth whoami

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -10,10 +10,9 @@ import (
 )
 
 var (
-	nextFlag   string
-	limitFlag  string
-	sortFlag   string
-	formatFlag string
+	nextFlag  string
+	limitFlag string
+	sortFlag  string
 )
 
 var appsCmd = &cobra.Command{
@@ -32,7 +31,6 @@ func init() {
 	appsCmd.Flags().StringVar(&nextFlag, "next", "", "Next parameter for paging")
 	appsCmd.Flags().StringVarP(&limitFlag, "limit", "l", "", "Limit parameter for paging")
 	appsCmd.Flags().StringVar(&sortFlag, "sort", "", "Sort by parameter for listing")
-	appsCmd.Flags().StringVar(&formatFlag, "format", "pretty", "Output format, one of: [pretty, json]")
 }
 
 func apps() error {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/bitrise-core/bitrise-plugins-io/configs"
-	"github.com/bitrise-core/bitrise-plugins-io/services"
 	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -43,16 +40,5 @@ func auth(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("Failed to set authentication token, error: %s", err)
 	}
 
-	response, err := services.ValidateAuthToken()
-	if err != nil {
-		return err
-	}
-
-	if response.Error != "" {
-		printErrorOutput(response.Error, formatFlag != "json")
-		os.Exit(1)
-		return nil
-	}
-	printOutput(response.Data, formatFlag != "json")
-	return nil
+	return errors.WithStack(whoami())
 }

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -5,7 +5,27 @@ import (
 	"fmt"
 
 	"github.com/bitrise-io/go-utils/log"
+	"github.com/pkg/errors"
 )
+
+// PrettyOutput ...
+type PrettyOutput interface {
+	Pretty() string
+}
+
+func printOutputWithPrettyFormatter(data []byte, pretty bool, prettyFormatter PrettyOutput) error {
+	var output string
+	if pretty {
+		if err := json.Unmarshal(data, prettyFormatter); err != nil {
+			return errors.WithStack(err)
+		}
+		output = prettyFormatter.Pretty()
+	} else {
+		output = string(data)
+	}
+	fmt.Println(output)
+	return nil
+}
 
 func printOutput(data []byte, pretty bool) {
 	var output string
@@ -25,7 +45,7 @@ func printOutput(data []byte, pretty bool) {
 	} else {
 		output = string(data)
 	}
-	fmt.Printf(output)
+	fmt.Println(output)
 }
 
 func printErrorOutput(message string, pretty bool) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	formatFlag string
+)
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "bitrise-plugins-io",
@@ -48,4 +52,6 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&configs.APIRootURL, "api-root-url", "https://api.bitrise.io/v0.1", "API root URL ($BITRISE_API_ROOT_URL)")
 	configs.APIRootURL = envutil.GetenvWithDefault("BITRISE_API_ROOT_URL", configs.APIRootURL)
+
+	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "pretty", "Output format, one of: [pretty, json]")
 }

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/bitrise-core/bitrise-plugins-io/services"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// whoamiCmd represents the whoami command
+var whoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Print info about the authenticated user",
+	Long:  `Print info about the authenticated user`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return errors.WithStack(whoami())
+	},
+}
+
+func init() {
+	authCmd.AddCommand(whoamiCmd)
+}
+
+// MeResponseModel ...
+type MeResponseModel struct {
+	Data struct {
+		Username string `json:"username"`
+		Slug     string `json:"slug"`
+	} `json:"data"`
+}
+
+// Pretty ...
+func (respModel *MeResponseModel) Pretty() string {
+	return fmt.Sprintf("%s (%s)", respModel.Data.Username, respModel.Data.Slug)
+}
+
+func whoami() error {
+	response, err := services.ValidateAuthToken()
+	if err != nil {
+		return err
+	}
+
+	if response.Error != "" {
+		printErrorOutput(response.Error, formatFlag != "json")
+		os.Exit(1)
+		return nil
+	}
+
+	return errors.WithStack(printOutputWithPrettyFormatter(response.Data, formatFlag != "json", &MeResponseModel{}))
+}


### PR DESCRIPTION
Fixes #25

- new command: auth whoami
- format moved to be a root level persistent flag
- new `printOutputWithPrettyFormatter` function and `PrettyOutput` interface