### PR TITLE
app command --sort flag option infos and command output revision

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,10 +40,10 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
 
 [[projects]]
   name = "github.com/spf13/pflag"
@@ -69,6 +69,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8b3bca6ada5d8a6a938b0413bb4ba4de169e9ac4ae6a00186175954cec83f0bc"
+  inputs-digest = "045f8c315aa90d905818edd9c4d895cea31fc49c473bfc7bf341175eee8a6f8d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/bitrise-core/bitrise-plugins-io/services"
+	"github.com/bitrise-io/go-utils/colorstring"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -13,6 +15,10 @@ var (
 	nextFlag  string
 	limitFlag string
 	sortFlag  string
+)
+
+const (
+	sortFlagDefault = "last_build_at"
 )
 
 var appsCmd = &cobra.Command{
@@ -30,10 +36,36 @@ func init() {
 	rootCmd.AddCommand(appsCmd)
 	appsCmd.Flags().StringVar(&nextFlag, "next", "", "Next parameter for paging")
 	appsCmd.Flags().StringVarP(&limitFlag, "limit", "l", "", "Limit parameter for paging")
-	appsCmd.Flags().StringVar(&sortFlag, "sort", "", "Sort by parameter for listing")
+	appsCmd.Flags().StringVar(&sortFlag, "sort", sortFlagDefault, "Sort by parameter for listing. Options: [created_at, last_build_at]")
+}
+
+// AppsResponseModel ...
+type AppsResponseModel struct {
+	Data []struct {
+		Title string `json:"title"`
+		Slug  string `json:"slug"`
+		Owner struct {
+			Name string `json:"name"`
+		} `json:"owner"`
+	} `json:"data"`
+}
+
+// Pretty ...
+func (respModel *AppsResponseModel) Pretty() string {
+	s := ""
+	for _, aAppData := range respModel.Data {
+		s += fmt.Sprintf("%s / %s (%s)\n", aAppData.Owner.Name, colorstring.Green(aAppData.Title), aAppData.Slug)
+	}
+	return s
 }
 
 func apps() error {
+	// for some reason the Cobra Flag default doesn't seem to work for the sortFlag var
+	// so doing it the manual way, ensuring default is set if needed
+	if sortFlag == "" {
+		sortFlag = sortFlagDefault
+	}
+
 	params := map[string]string{
 		"next":    nextFlag,
 		"limit":   limitFlag,
@@ -50,6 +82,6 @@ func apps() error {
 		os.Exit(1)
 		return nil
 	}
-	printOutput(response.Data, formatFlag != "json")
+	printOutputWithPrettyFormatter(response.Data, formatFlag != "json", &AppsResponseModel{})
 	return nil
 }

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -82,6 +82,5 @@ func apps() error {
 		os.Exit(1)
 		return nil
 	}
-	printOutputWithPrettyFormatter(response.Data, formatFlag != "json", &AppsResponseModel{})
-	return nil
+	return errors.WithStack(printOutputWithPrettyFormatter(response.Data, formatFlag != "json", &AppsResponseModel{}))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,15 +21,14 @@ var rootCmd = &cobra.Command{
 	Short: "Command Line User Interface for bitrise.io",
 	Long: `Command Line User Interface for bitrise.io
 
---------------------------------------------------
-If you use it as a Bitrise CLI plugin:
-  $ bitrise :io [command]
-
-If you use it as a stand-alone tool:
-  $ env BITRISE_PLUGIN_INPUT_DATA_DIR=/path/where/login/data/should/be/stored \
-    bitrise-plugins-io [command]
---------------------------------------------------
+Uses the official Bitrise API (v0.1 docs: https://devcenter.bitrise.io/api/v0.1/ )
 `,
+	Example: `  If you use it as a Bitrise CLI plugin:
+    $ bitrise :io [command]
+
+  If you use it as a stand-alone tool:
+    $ env BITRISE_PLUGIN_INPUT_DATA_DIR=/path/where/login/data/should/be/stored \
+      bitrise-plugins-io [command]`,
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.


### PR DESCRIPTION
fixes #23

- help texts now include the available options for the `--sort` flag of the apps command
- default was also changed to match the bitrise.io dashboard
- output format revision, using the new `PrettyOutput` interface