### PR TITLE
fixing golint path

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -40,7 +40,7 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -ex
-            go get -u github.com/golang/lint/golint
+            go get -u golang.org/x/lint/golint
             while read -r line; do
               echo "-> Linting: $line"
               golint_out="$(golint $line)"


### PR DESCRIPTION
Was moved from github.com/golang/lint/golint to golang.org/x/lint/golint